### PR TITLE
envsetup: Fix check for deprecated CM device tree

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -63,11 +63,12 @@ function breakfast()
             if [ -z "$variant" ]; then
                 variant="userdebug"
             fi
-            lunch lineage_$target-$variant
-            if [ $? -ne 0 ]; then
-                # try CM
+
+            if ! check_product lineage_$target && check_product cm_$target; then
                 echo "** Warning: '$target' is using CM-based makefiles. This will be deprecated in the next major release."
                 lunch cm_$target-$variant
+            else
+                lunch lineage_$target-$variant
             fi
         fi
     fi


### PR DESCRIPTION
By the time lunch is run on a product name, it's too late to check
whether a deprecated CM device tree is being used (roomservice runs in
lunch). Instead, rely on check_product() to identify whether a tree
uses cm_ or lineage_ before running lunch.

Change-Id: I16288365f791ff68c3226f3808427168b2fc06fa